### PR TITLE
Example react-window integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "dependencies": {
     "@material-ui/core": "^3.2.2",
     "@material-ui/icons": "^3.0.1",
+    "memoize-one": "^4.0.2",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
-    "react-scripts": "2.0.5"
+    "react-scripts": "2.0.5",
+    "react-virtualized-auto-sizer": "^1.0.2",
+    "react-window": "^1.2.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/LocationsGrid.js
+++ b/src/components/LocationsGrid.js
@@ -1,37 +1,81 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
-import AppBar from "@material-ui/core/AppBar";
-import Toolbar from "@material-ui/core/Toolbar";
 import { withStyles } from "@material-ui/core/styles";
 import LocationCard from "./LocationCard.js";
-import Grid from "@material-ui/core/Grid";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { FixedSizeList as List } from "react-window";
+import memoize from "memoize-one";
+
+const CARD_SIZE = 340;
 
 const styles = theme => ({
   root: {
     padding: "0 85px",
     marginTop: 20,
     justifyContent: "flex-start"
+  },
+  Row: {
+    display: "flex",
+    justifyContent: "space-around",
   }
 });
 
-class LocationsGrid extends React.Component {
+class Row extends PureComponent {
+  render() {
+    const { data, index, style } = this.props;
+    const { classes, itemsPerRow, locations } = data;
+ 
+    const items = [];
+    const fromIndex = index * itemsPerRow;
+    const toIndex = Math.min(fromIndex + itemsPerRow, locations.length);
+
+    for (let i = fromIndex; i < toIndex; i++) {
+      items.push(
+        <LocationCard key={i} location={locations[i]} />
+      );
+    }
+
+    return (
+      <div className={classes.Row} style={style}>
+        {items}
+      </div>
+    );
+  }
+}
+
+class LocationsGrid extends PureComponent {
+  getItemData = memoize((classes, itemsPerRow, locations) => ({
+    classes,
+    itemsPerRow,
+    locations
+  }))
+
   render() {
     const { locations, classes } = this.props;
 
     return (
-      <div className={classes.root}>
-        <Grid
-          container
-          
-          justify="flex-start"
-          spacing={16}
-        >
-          {locations.map((location, index) => (
-            <Grid key={index} item>
-              <LocationCard location={location} />
-            </Grid>
-          ))}
-        </Grid>
+      <div style={{ marginTop: "10px", height: "80vh" }}>
+        <AutoSizer>
+          {({ height, width }) => {
+            const itemsPerRow = Math.floor(width / CARD_SIZE) || 1;
+            const rowCount = Math.ceil(locations.length / itemsPerRow);
+            const itemData = this.getItemData(classes, itemsPerRow, locations);
+      
+            return (
+              <div>
+                <List
+                  height={height}
+                  itemCount={rowCount}
+                  itemData={itemData}
+                  itemSize={CARD_SIZE}
+                  width={width}
+                >
+                  {Row}
+                </List>
+              </div>
+            );
+          }}
+        </AutoSizer>
       </div>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5246,6 +5246,16 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-3.1.1.tgz#ef609811e3bc28970eac2884eece64d167830d17"
+  integrity sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA==
+
+memoize-one@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+  integrity sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -6974,6 +6984,19 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-virtualized-auto-sizer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
+  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
+
+react-window@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.2.2.tgz#dba6e1029e26df0fb1f2cf1aa3559c2d7eaf6d0a"
+  integrity sha512-0gwx14I8tgMwRk09c9ZGY7mAh6G4VvTdrrMJjsoH60ijb0jffYxlFLQHvSX5S9DD39ZyNnaiQ3t9vTFIQb68XA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one "^3.1.1"
 
 react@^16.5.2:
   version "16.5.2"


### PR DESCRIPTION
Hi! I saw [your post on Reddit](https://www.reddit.com/r/reactjs/comments/9tpk8k/reactvirtualized_materialui_cards_for_fast_lists/) and wanted to share how you could integrate with [react-window](https://react-window.now.sh) as opposed to react-virtualized. 😄

Using the [React DevTools profiler](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html), I observed that the app initially took ~756ms to render the list of cards:
<img width="1174" alt="screen shot 2018-11-02 at 9 22 46 pm" src="https://user-images.githubusercontent.com/29597/47948044-35210180-dee6-11e8-8330-5803d3484048.png">

After plugging in react-window, the initial render dropped to ~31ms (and updates stayed fast as well):
<img width="1175" alt="screen shot 2018-11-02 at 9 23 30 pm" src="https://user-images.githubusercontent.com/29597/47948045-35b99800-dee6-11e8-95b7-408e437b06ae.png">
